### PR TITLE
Add richer admin dashboard with charts and latest invoices

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -7,6 +7,8 @@ body { background: #f6f8fb; }
 .table-sm td, .table-sm th { padding: .4rem; }
 .card-kpi { border: 1px solid #eef1f6; }
 .print-area { background: #fff; padding: 20px; }
+.dashboard-list li { font-size: 14px; padding: 4px 0; }
+.dashboard-list li + li { border-top: 1px solid #eef1f6; }
 @media print {
   .no-print { display: none; }
   .content { margin: 0; }

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -14,4 +14,19 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   }
+
+  // Doughnut chart for category distribution
+  const ctx2 = document.getElementById('categoryChart');
+  if (ctx2) {
+    const labels = JSON.parse(ctx2.dataset.labels || '[]');
+    const values = JSON.parse(ctx2.dataset.values || '[]');
+    new Chart(ctx2, {
+      type: 'doughnut',
+      data: {
+        labels: labels,
+        datasets: [{ data: values, backgroundColor: ['#4e79a7','#f28e2b','#e15759','#76b7b2'] }]
+      },
+      options: { plugins: { legend: { position: 'bottom' } } }
+    });
+  }
 });

--- a/views/dashboard/index.php
+++ b/views/dashboard/index.php
@@ -2,34 +2,72 @@
 <div class="d-flex justify-content-between align-items-center mb-4">
   <h4 class="mb-0">Dashboard</h4>
 </div>
+
 <div class="row g-3">
-  <div class="col-12 col-md-3">
-    <div class="card card-kpi p-3">
+  <div class="col-6 col-md-3">
+    <div class="card card-kpi p-3 h-100">
       <div class="small text-muted">Total tenants</div>
       <div class="h4 mb-0"><?= e($kpis['tenants'] ?? 0) ?></div>
     </div>
   </div>
-  <div class="col-12 col-md-3">
-    <div class="card card-kpi p-3">
+  <div class="col-6 col-md-3">
+    <div class="card card-kpi p-3 h-100">
       <div class="small text-muted">Total units</div>
       <div class="h4 mb-0"><?= e($kpis['units'] ?? 0) ?></div>
     </div>
   </div>
-  <div class="col-12 col-md-3">
-    <div class="card card-kpi p-3">
+  <div class="col-6 col-md-3">
+    <div class="card card-kpi p-3 h-100">
       <div class="small text-muted">Outstanding</div>
       <div class="h4 mb-0">৳ <?= e(number_format($kpis['outstanding'] ?? 0, 0)) ?></div>
     </div>
   </div>
-  <div class="col-12 col-md-3">
-    <div class="card card-kpi p-3">
+  <div class="col-6 col-md-3">
+    <div class="card card-kpi p-3 h-100">
       <div class="small text-muted">Collection (MTD)</div>
       <div class="h4 mb-0">৳ <?= e(number_format($kpis['collection_mtd'] ?? 0, 0)) ?></div>
     </div>
   </div>
 </div>
 
-<div class="card mt-4 p-3">
-  <h6>Product sales</h6>
-  <canvas id="salesChart" height="100"></canvas>
+<div class="row g-3 mt-1">
+  <div class="col-12 col-lg-8">
+    <div class="card p-3 h-100">
+      <h6>Product sales</h6>
+      <canvas id="salesChart" height="120"></canvas>
+    </div>
+  </div>
+  <div class="col-12 col-lg-4">
+    <div class="card p-3 h-100">
+      <h6>Sales by product category</h6>
+      <canvas id="categoryChart" data-labels='<?= json_encode($categoryData['labels']) ?>' data-values='<?= json_encode($categoryData['values']) ?>' height="180"></canvas>
+    </div>
+  </div>
+</div>
+
+<div class="row g-3 mt-1">
+  <div class="col-12 col-lg-6">
+    <div class="card p-3 h-100">
+      <h6>Latest invoices</h6>
+      <ul class="dashboard-list list-unstyled mb-0">
+        <?php foreach ($latestInvoices as $inv): ?>
+          <li class="d-flex justify-content-between">
+            <span><?= e($inv['tenant'] ?? 'Unknown') ?></span>
+            <span>৳ <?= e(number_format($inv['amount'] ?? 0, 0)) ?></span>
+          </li>
+        <?php endforeach; ?>
+        <?php if (empty($latestInvoices)): ?>
+          <li class="text-muted">No invoices yet</li>
+        <?php endif; ?>
+      </ul>
+    </div>
+  </div>
+  <div class="col-12 col-lg-6">
+    <div class="card p-3 h-100">
+      <h6>Sales by countries</h6>
+      <div class="ratio ratio-4x3 bg-light d-flex align-items-center justify-content-center text-muted">
+        Map placeholder
+      </div>
+    </div>
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- Extend dashboard controller to fetch latest invoices and provide sample category data
- Redesign dashboard view with KPI cards, bar and doughnut charts, and invoice list
- Add chart initialization and list styling

## Testing
- `php -l controllers/DashboardController.php`
- `php -l views/dashboard/index.php`


------
https://chatgpt.com/codex/tasks/task_b_68af32bf268c832fa1e7bf09fbc9ed36